### PR TITLE
fix/import-extensions

### DIFF
--- a/packages/eslint-config-oval-base/rules/imports.js
+++ b/packages/eslint-config-oval-base/rules/imports.js
@@ -138,11 +138,15 @@ module.exports = {
 
     // Ensure consistent use of file extension within the import path
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    'import/extensions': ['error', 'ignorePackages', {
-      js: 'never',
-      mjs: 'never',
-      jsx: 'never',
-    }],
+    "import/extensions": ["error", {
+      "js": "never",
+      "mjs": "never",
+      "jsx": "never",
+      "ts": "never",
+      "tsx": "never",
+      "json": "always",
+      "pcss": "always"
+    }]
 
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md

--- a/packages/eslint-config-oval-base/rules/imports.js
+++ b/packages/eslint-config-oval-base/rules/imports.js
@@ -138,14 +138,14 @@ module.exports = {
 
     // Ensure consistent use of file extension within the import path
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    "import/extensions": ["error", {
-      "js": "never",
-      "mjs": "never",
-      "jsx": "never",
-      "ts": "never",
-      "tsx": "never",
-      "json": "always",
-      "pcss": "always"
+    'import/extensions': ['error', {
+      js: 'never',
+      mjs: 'never',
+      jsx: 'never',
+      ts: 'never',
+      tsx: 'never',
+      json: 'always',
+      pcss: 'always'
     }],
 
     // ensure absolute imports are above relative imports and that unassigned imports are ignored

--- a/packages/eslint-config-oval-base/rules/imports.js
+++ b/packages/eslint-config-oval-base/rules/imports.js
@@ -146,7 +146,7 @@ module.exports = {
       "tsx": "never",
       "json": "always",
       "pcss": "always"
-    }]
+    }],
 
     // ensure absolute imports are above relative imports and that unassigned imports are ignored
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md


### PR DESCRIPTION
Since [ignorePackages changed its behaviour](https://github.com/benmosher/eslint-plugin-import/pull/1521) with one of the latest update of the related package, we need to fix the rule to make it work again as expected, for us.